### PR TITLE
Pin CKEditor dev dependeny to last OS release.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
 		}
 	],
 	"devDependencies": {
-		"ckeditor": "4"
+		"ckeditor": "4.22.1"
 	}
 }


### PR DESCRIPTION
There will be no new open source releases for the 4.x branch anymore, only commercial LTS ones.